### PR TITLE
Improve node linking behavior

### DIFF
--- a/node_gui.py
+++ b/node_gui.py
@@ -3,6 +3,8 @@ import math
 import uuid
 from dearpygui import dearpygui as dpg
 
+"""Node based calculator GUI."""
+
 
 # containers for the graph system
 nodes = {}
@@ -12,6 +14,11 @@ node_count = 0
 x_data = []
 y_data = []
 start_time = time.time()
+
+# themes for highlighting active nodes
+active_node_theme = dpg.add_theme()
+with dpg.theme_component(dpg.mvNode):
+    dpg.add_theme_color(dpg.mvNodeCol_TitleBar, (0, 150, 250, 255))
 
 
 def _register_attr(node, attr):
@@ -24,6 +31,50 @@ def _link_lookup(attr):
         if l["dest"] == attr:
             return l["source"]
     return None
+
+
+def _find_widget_for_attr(node_tag, attr):
+    """Return widget associated with the given attribute if any."""
+    node = nodes.get(node_tag, {})
+    for key, value in node.items():
+        if key.endswith("_widget") and node.get(key[:-7]) == attr:
+            return value
+    return None
+
+
+def _toggle_attr_widget(attr, enable):
+    owner = attr_owner.get(attr)
+    if not owner:
+        return
+    widget = _find_widget_for_attr(owner, attr)
+    if widget and dpg.does_item_exist(widget):
+        if enable:
+            dpg.enable_item(widget)
+        else:
+            dpg.disable_item(widget)
+
+
+def _remove_existing_link(dest_attr):
+    for l in links:
+        if l["dest"] == dest_attr:
+            dpg.delete_item(l["id"])
+            links.remove(l)
+            dest_owner = attr_owner.get(dest_attr)
+            if dest_owner and dest_attr in nodes[dest_owner].get("links", {}):
+                del nodes[dest_owner]["links"][dest_attr]
+            _toggle_attr_widget(dest_attr, True)
+            break
+
+
+def _highlight_node(node_tag):
+    """Temporarily highlight an active node."""
+    if not dpg.does_item_exist(node_tag):
+        return
+    dpg.bind_item_theme(node_tag, active_node_theme)
+    dpg.set_frame_callback(
+        dpg.get_frame_count() + 1,
+        lambda: dpg.bind_item_theme(node_tag, 0) if dpg.does_item_exist(node_tag) else None,
+    )
 
 
 def _get_input_value(attr, widget=None):
@@ -41,6 +92,7 @@ def _get_input_value(attr, widget=None):
 def _evaluate_node(tag):
     node = nodes[tag]
     ntype = node["type"]
+    _highlight_node(tag)
 
     if ntype == "time":
         value = time.time() - start_time
@@ -80,6 +132,9 @@ def _evaluate_node(tag):
         x_data.append(time.time() - start_time)
         y_data.append(value)
         dpg.set_value(node["series"], [x_data, y_data])
+        if x_data:
+            start = max(0.0, x_data[-1] - 10)
+            dpg.set_axis_limits("plot_xaxis", start, x_data[-1])
     else:
         value = 0.0
 
@@ -95,11 +150,13 @@ def _process_graph():
 def link_callback(sender, app_data):
     source_attr = dpg.get_item_alias(app_data[0])
     dest_attr = dpg.get_item_alias(app_data[1])
+    _remove_existing_link(dest_attr)
     link_id = dpg.add_node_link(source_attr, dest_attr, parent=sender)
     links.append({"id": link_id, "source": source_attr, "dest": dest_attr})
     dest_owner = attr_owner.get(dest_attr)
     if dest_owner:
         nodes[dest_owner].setdefault("links", {})[dest_attr] = source_attr
+    _toggle_attr_widget(dest_attr, False)
 
 
 def delink_callback(sender, app_data):
@@ -109,6 +166,7 @@ def delink_callback(sender, app_data):
             dest_owner = attr_owner.get(link["dest"])
             if dest_owner and link["dest"] in nodes[dest_owner].get("links", {}):
                 del nodes[dest_owner]["links"][link["dest"]]
+            _toggle_attr_widget(link["dest"], True)
             links.remove(link)
             break
 
@@ -273,7 +331,7 @@ with dpg.window(label="Node Editor"):
 
 with dpg.window(label="Plot Window"):
     with dpg.plot(label="Sine", height=400, width=400):
-        dpg.add_plot_axis(dpg.mvXAxis, label="x")
+        dpg.add_plot_axis(dpg.mvXAxis, label="x", tag="plot_xaxis")
         with dpg.plot_axis(dpg.mvYAxis, label="y", tag="plot_yaxis"):
             dpg.add_line_series([], [], parent="plot_yaxis", tag="sine_series")
 


### PR DESCRIPTION
## Summary
- add theme and highlight utility helpers
- enforce one inbound link per attribute and disable widgets when linked
- allow nodes to flash when evaluated
- update plot to track new data
- tag x-axis for live axis limit updates

## Testing
- `python -m py_compile node_gui.py`

------
https://chatgpt.com/codex/tasks/task_e_6840061b26fc8326abe789cbd536b233